### PR TITLE
Provide an abstract factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 1.0.1 - TBD
+## 1.1.0 - 2019-02-07
 
 ### Added
 
-- Nothing.
+- [#1](https://github.com/phly/phly-expressive-configfactory/pull/1) adds `ConfigAbstractFactory`, a zend-servicemanager abstract factory for
+  auto-wiring configuration services.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,32 @@ class BlogCacheFactory
 }
 ```
 
+### Abstract Factory
+
+> Since 1.1.0
+
+If you are using [zend-servicemanager](https://docs.zendframework.com/zend-servicemanager),
+you can use the class `Phly\Expressive\ConfigAbstractFactory` as an abstract
+factory. This allows you to omit adding a factory entry for every configuration
+segment you want to retrieve. Instead, you can add the following:
+
+```php
+return [
+    'dependencies' => [
+        'abstract_factories' => [
+            \Phly\Expressive\ConfigAbstractFactory::class,
+
+            // OR
+
+            new \Phly\Expressive\ConfigAbstractFactory(false),
+        ],
+    ],
+];
+```
+
+When present, it will handle any services with the prefix `config-`, and operate
+in the same way as the `ConfigFactory`.
+
 ### Caveats
 
 You should only specify keys that will return an array. Most containers only

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,11 @@
     "require-dev": {
         "phpunit/phpunit": "^7.1.1",
         "webimpress/coding-standard": "dev-master@dev",
-        "zendframework/zend-coding-standard": "~2.0.0@alpha"
+        "zendframework/zend-coding-standard": "~2.0.0@alpha",
+        "zendframework/zend-servicemanager": "^3.4"
+    },
+    "suggest": {
+        "zendframework/zend-servicemanager": "Install zend-servicemanager to use the ConfigAbstractFactory"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8ad1b67f2fcfa1503f027cf09a31f2f2",
+    "content-hash": "0fa0ea00c9582524ff2e2175491cf429",
     "packages": [
         {
             "name": "psr/container",
@@ -57,6 +57,37 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "container-interop/container-interop",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "homepage": "https://github.com/container-interop/container-interop",
+            "time": "2017-02-14T19:40:03+00:00"
+        },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.5.0",
@@ -1768,6 +1799,120 @@
                 "zf"
             ],
             "time": "2019-01-01T19:08:39+00:00"
+        },
+        {
+            "name": "zendframework/zend-servicemanager",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-servicemanager.git",
+                "reference": "a1ed6140d0d3ee803fec96582593ed024950067b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/a1ed6140d0d3ee803fec96582593ed024950067b",
+                "reference": "a1ed6140d0d3ee803fec96582593ed024950067b",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.2",
+                "php": "^5.6 || ^7.0",
+                "psr/container": "^1.0",
+                "zendframework/zend-stdlib": "^3.2.1"
+            },
+            "provide": {
+                "container-interop/container-interop-implementation": "^1.2",
+                "psr/container-implementation": "^1.0"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "^1.6.5",
+                "ocramius/proxy-manager": "^1.0 || ^2.0",
+                "phpbench/phpbench": "^0.13.0",
+                "phpunit/phpunit": "^5.7.25 || ^6.4.4",
+                "zendframework/zend-coding-standard": "~1.0.0"
+            },
+            "suggest": {
+                "ocramius/proxy-manager": "ProxyManager 1.* to handle lazy initialization of services",
+                "zendframework/zend-stdlib": "zend-stdlib ^2.5 if you wish to use the MergeReplaceKey or MergeRemoveKey features in Config instances"
+            },
+            "bin": [
+                "bin/generate-deps-for-config-factory",
+                "bin/generate-factory-for-class"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev",
+                    "dev-develop": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\ServiceManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Factory-Driven Dependency Injection Container",
+            "keywords": [
+                "PSR-11",
+                "ZendFramework",
+                "dependency-injection",
+                "di",
+                "dic",
+                "service-manager",
+                "servicemanager",
+                "zf"
+            ],
+            "time": "2018-12-22T06:05:09+00:00"
+        },
+        {
+            "name": "zendframework/zend-stdlib",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-stdlib.git",
+                "reference": "66536006722aff9e62d1b331025089b7ec71c065"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/66536006722aff9e62d1b331025089b7ec71c065",
+                "reference": "66536006722aff9e62d1b331025089b7ec71c065",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpbench/phpbench": "^0.13",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
+                "zendframework/zend-coding-standard": "~1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev",
+                    "dev-develop": "3.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "SPL extensions, array utilities, error handlers, and more",
+            "keywords": [
+                "ZendFramework",
+                "stdlib",
+                "zf"
+            ],
+            "time": "2018-08-28T21:34:05+00:00"
         }
     ],
     "aliases": [],

--- a/src/ConfigAbstractFactory.php
+++ b/src/ConfigAbstractFactory.php
@@ -9,8 +9,11 @@ declare(strict_types=1);
 
 namespace Phly\Expressive;
 
+use ArrayObject;
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\Factory\AbstractFactoryInterface;
+
+use function preg_match;
 
 class ConfigAbstractFactory implements AbstractFactoryInterface
 {
@@ -20,11 +23,11 @@ class ConfigAbstractFactory implements AbstractFactoryInterface
     }
 
     /**
-     * @return array|\ArrayObject
+     * @return array|ArrayObject
      * @throws InvalidServiceNameException if $serviceName does not begin with "config-"
      * @throws ConfigKeyNotFoundException if $returnArrayForUnfoundKey is false and the key is not found
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         return $this->getRequestedConfig($container, $requestedName);
     }

--- a/src/ConfigAbstractFactory.php
+++ b/src/ConfigAbstractFactory.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @see       https://github.com/phly/phly-expressive-configfactory for the canonical source repository
+ * @copyright Copyright (c) Matthew Weier O'Phinney (https://mwop.net)
+ * @license   https://github.com/phly/phly-expresive-configfactory/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\Expressive;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\AbstractFactoryInterface;
+
+class ConfigAbstractFactory implements AbstractFactoryInterface
+{
+    public function canCreate(ContainerInterface $container, $requestedName) : bool
+    {
+        return (bool) preg_match('/^config-/i', $requestedName);
+    }
+
+    /**
+     * @return array|\ArrayObject
+     * @throws InvalidServiceNameException if $serviceName does not begin with "config-"
+     * @throws ConfigKeyNotFoundException if $returnArrayForUnfoundKey is false and the key is not found
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        return $this->getRequestedConfig($container, $requestedName);
+    }
+}

--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Phly\Expressive;
 
+use ArrayObject;
 use Psr\Container\ContainerInterface;
 
 class ConfigFactory
@@ -16,7 +17,7 @@ class ConfigFactory
     use GetRequestedConfigTrait;
 
     /**
-     * @return array|\ArrayObject
+     * @return array|ArrayObject
      * @throws InvalidServiceNameException if $serviceName does not begin with "config-"
      * @throws ConfigKeyNotFoundException if $returnArrayForUnfoundKey is false and the key is not found
      */

--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -11,67 +11,17 @@ namespace Phly\Expressive;
 
 use Psr\Container\ContainerInterface;
 
-use function array_key_exists;
-use function array_merge;
-use function array_shift;
-use function explode;
-use function preg_match;
-use function substr;
-
 class ConfigFactory
 {
-    /** @var bool */
-    private $returnArrayForUnfoundKey;
-
-    public static function __set_state(array $properties) : self
-    {
-        return new static($properties['returnArrayForUnfoundKey']);
-    }
-
-    public function __construct(bool $returnArrayForUnfoundKey = true)
-    {
-        $this->returnArrayForUnfoundKey = $returnArrayForUnfoundKey;
-    }
+    use GetRequestedConfigTrait;
 
     /**
-     * @return array|ArrayObject
+     * @return array|\ArrayObject
      * @throws InvalidServiceNameException if $serviceName does not begin with "config-"
      * @throws ConfigKeyNotFoundException if $returnArrayForUnfoundKey is false and the key is not found
      */
-    public function __invoke(ContainerInterface $container, string $serviceName = 'config')
+    public function __invoke(ContainerInterface $container, string $serviceName = '')
     {
-        if (! preg_match('/^config-/i', $serviceName)) {
-            throw InvalidServiceNameException::forService($serviceName);
-        }
-
-        $config = $container->get('config');
-        $key    = substr($serviceName, 7);
-        $keys   = explode('.', $key);
-
-        return $this->getConfigForKeys($config, $keys);
-    }
-
-    /**
-     * @return array|ArrayObject
-     * @throws ConfigKeyNotFoundException if $returnArrayForUnfoundKey is false and the key is not found
-     */
-    private function getConfigForKeys(array $config, array $keys, array $parentKeys = [])
-    {
-        if (empty($keys)) {
-            return $config;
-        }
-
-        $key = array_shift($keys);
-
-        if (! array_key_exists($key, $config)) {
-            if ($this->returnArrayForUnfoundKey) {
-                return [];
-            }
-
-            throw ConfigKeyNotFoundException::forNestedKey(array_merge([$key], $parentKeys));
-        }
-
-        $parentKeys[] = $key;
-        return $this->getConfigForKeys($config[$key], $keys, $parentKeys);
+        return $this->getRequestedConfig($container, $serviceName);
     }
 }

--- a/src/GetRequestedConfigTrait.php
+++ b/src/GetRequestedConfigTrait.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @see       https://github.com/phly/phly-expressive-configfactory for the canonical source repository
+ * @copyright Copyright (c) Matthew Weier O'Phinney (https://mwop.net)
+ * @license   https://github.com/phly/phly-expresive-configfactory/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\Expressive;
+
+use Psr\Container\ContainerInterface;
+
+use function array_key_exists;
+use function array_merge;
+use function array_shift;
+use function explode;
+use function preg_match;
+use function substr;
+
+trait GetRequestedConfigTrait
+{
+    /** @var bool */
+    private $returnArrayForUnfoundKey;
+
+    public static function __set_state(array $properties) : self
+    {
+        return new static($properties['returnArrayForUnfoundKey']);
+    }
+
+    public function __construct(bool $returnArrayForUnfoundKey = true)
+    {
+        $this->returnArrayForUnfoundKey = $returnArrayForUnfoundKey;
+    }
+
+    /**
+     * @return array|\ArrayObject
+     * @throws InvalidServiceNameException if $serviceName does not begin with "config-"
+     * @throws ConfigKeyNotFoundException if $returnArrayForUnfoundKey is false and the key is not found
+     */
+    private function getRequestedConfig(ContainerInterface $container, string $serviceName)
+    {
+        if (! preg_match('/^config-/i', $serviceName)) {
+            throw InvalidServiceNameException::forService($serviceName);
+        }
+
+        $config = $container->get('config');
+        $key    = substr($serviceName, 7);
+        $keys   = explode('.', $key);
+
+        return $this->getConfigForKeys($config, $keys);
+    }
+
+    /**
+     * @return array|\ArrayObject
+     * @throws ConfigKeyNotFoundException if $returnArrayForUnfoundKey is false and the key is not found
+     */
+    private function getConfigForKeys(array $config, array $keys, array $parentKeys = [])
+    {
+        if (empty($keys)) {
+            return $config;
+        }
+
+        $key = array_shift($keys);
+
+        if (! array_key_exists($key, $config)) {
+            if ($this->returnArrayForUnfoundKey) {
+                return [];
+            }
+
+            throw ConfigKeyNotFoundException::forNestedKey(array_merge([$key], $parentKeys));
+        }
+
+        $parentKeys[] = $key;
+        return $this->getConfigForKeys($config[$key], $keys, $parentKeys);
+    }
+}

--- a/src/GetRequestedConfigTrait.php
+++ b/src/GetRequestedConfigTrait.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Phly\Expressive;
 
+use ArrayObject;
 use Psr\Container\ContainerInterface;
 
 use function array_key_exists;
@@ -34,7 +35,7 @@ trait GetRequestedConfigTrait
     }
 
     /**
-     * @return array|\ArrayObject
+     * @return array|ArrayObject
      * @throws InvalidServiceNameException if $serviceName does not begin with "config-"
      * @throws ConfigKeyNotFoundException if $returnArrayForUnfoundKey is false and the key is not found
      */
@@ -52,7 +53,7 @@ trait GetRequestedConfigTrait
     }
 
     /**
-     * @return array|\ArrayObject
+     * @return array|ArrayObject
      * @throws ConfigKeyNotFoundException if $returnArrayForUnfoundKey is false and the key is not found
      */
     private function getConfigForKeys(array $config, array $keys, array $parentKeys = [])

--- a/test/ConfigAbstractFactoryTest.php
+++ b/test/ConfigAbstractFactoryTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @see       https://github.com/phly/phly-expressive-configfactory for the canonical source repository
+ * @copyright Copyright (c) Matthew Weier O'Phinney (https://mwop.net)
+ * @license   https://github.com/phly/phly-expresive-configfactory/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace PhlyTest\Expressive;
+
+use Interop\Container\ContainerInterface;
+use Phly\Expressive\ConfigAbstractFactory;
+use PHPUnit\Framework\TestCase;
+
+class ConfigAbstractFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class)->reveal();
+        $this->factory   = new ConfigAbstractFactory();
+    }
+
+    public function testCanCreateReturnsFalseForInvalidServiceName()
+    {
+        $this->assertFalse($this->factory->canCreate($this->container, 'invalid-name'));
+    }
+
+    public function testCanCreateReturnsTrueForValidServiceName()
+    {
+        $this->assertTrue($this->factory->canCreate($this->container, 'config-some.key'));
+    }
+}


### PR DESCRIPTION
This patch adds the class `ConfigAbstractFactory`, which is a zend-servicemanager abstract factory that can be registered once to handle any configuration segment request (instead of registering a factory per configuration segment).
